### PR TITLE
Fix incorrect classname in laravel autodiscover config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "LivewireAutocomplete\\ServiceProvider"
+                "LivewireAutocomplete\\LivewireAutocompleteServiceProvider"
             ]
         }
     },


### PR DESCRIPTION
Package cannot install as auto discover information is using an incorrect Classname:

This was changed in the "Fix tests" commit.

`LivewireAutocomplete\\ServiceProvider` 

should be

`LivewireAutocomplete\\LivewireAutocompleteServiceProvider`
