### PR TITLE
Fix esc closing

### DIFF
--- a/resources/views/components/autocomplete/index.blade.php
+++ b/resources/views/components/autocomplete/index.blade.php
@@ -13,7 +13,7 @@
         fireEvents: @js(!$disableEvents),
     })"
     x-on:{{ $name }}-clear.window="fireEvents && clear()"
-    x-on:keydown.escape="escape($event)"
+    x-on:keydown.escape.stop="escape($event)"
     x-on:click.outside="outside()"
     {{ $attributes->whereDoesntStartWith('wire:model')->class(['' => !$unstyled, 'relative']) }}>
     {{ $slot }}


### PR DESCRIPTION
Right now if you use `esc` to close the drop down, the event bubbles up and may trigger other esc key handlers, like in a modal.