### PR TITLE
Component option to allow editing the selection and fix on double selection

### DIFF
--- a/resources/js/autocomplete.js
+++ b/resources/js/autocomplete.js
@@ -254,9 +254,13 @@ document.addEventListener('livewire:init', () => {
         },
 
         setSelected($dispatch, selected) {
-            this.decoupledValue = null
+            const newValue = typeof selected === 'object' && selected.hasOwnProperty(this.searchAttribute) ? selected[this.searchAttribute] : selected
+            if (newValue === this.value) {
+                return
+            }
 
-            this.value = typeof selected === 'object' && selected.hasOwnProperty(this.searchAttribute) ? selected[this.searchAttribute] : selected
+            this.decoupledValue = null
+            this.value = newValue
             this.selected = typeof selected === 'object' && selected.hasOwnProperty(this.idAttribute) ? selected[this.idAttribute] : selected
             $dispatch((this.name ?? 'autocomplete') + '-selected-object', selected)
             $dispatch((this.name ?? 'autocomplete') + '-selected', this.selected)

--- a/resources/views/autocomplete.blade.php
+++ b/resources/views/autocomplete.blade.php
@@ -12,6 +12,7 @@ $resultsValue = $this->getPropertyValue($resultsProperty->value);
 
 $autoSelect = filter_var($getOption('auto-select'), FILTER_VALIDATE_BOOLEAN);
 $allowNew = filter_var($getOption('allow-new'), FILTER_VALIDATE_BOOLEAN);
+$allowSelectionEdition = filter_var($getOption('allow-selection-edition'), FILTER_VALIDATE_BOOLEAN);
 $loadOnceOnFocus = filter_var($getOption('load-once-on-focus'), FILTER_VALIDATE_BOOLEAN);
 $inline = filter_var($getOption('inline'), FILTER_VALIDATE_BOOLEAN);
 @endphp
@@ -29,6 +30,7 @@ $inline = filter_var($getOption('inline'), FILTER_VALIDATE_BOOLEAN);
         searchAttribute: '{{ $getOption('text') }}',
         autoSelect: {{ $autoSelect ? 'true' : 'false' }},
         allowNew: {{ $allowNew ? 'true' : 'false' }},
+        allowSelectionEdition: {{ $allowSelectionEdition ? 'true' : 'false' }},
         loadOnceOnFocus: {{ $loadOnceOnFocus ? 'true' : 'false' }},
     })"
     x-init="init($dispatch)"

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -3,4 +3,4 @@
     autocomplete="off"
     {{ $attributes->class('w-full pl-4 py-2 rounded border border-cool-gray-200 shadow-inner leading-5 text-cool-gray-900 placeholder-cool-gray-400 focus:outline-none focus:border-blue-400 disabled:bg-cool-gray-100') }}
     x-bind:class="[selected ? 'pr-9' : 'pr-4']"
-    x-bind:disabled="selected" />
+    x-bind:disabled="selected && !allowSelectionEdition" />


### PR DESCRIPTION
This PR adds the option "allow-selection-edition" to allow editing the selection and fixes deleting the selection when clicking the selected option again (only visible with the new option to true > cf screen-cast using demo app).

[ScreencastSelectionRemovedOnReSelect.webm](https://github.com/user-attachments/assets/60210245-2b13-4cd3-acc7-977f32a1e235)
