### PR TITLE
Use attributes instead of annotations for PHPUnit 12

### DIFF
--- a/tests/Browser/AllowNewTest/AllowNewTest.php
+++ b/tests/Browser/AllowNewTest/AllowNewTest.php
@@ -7,7 +7,7 @@ use LivewireAutocomplete\Tests\Browser\TestCase;
 
 class AllowNewTest extends TestCase
 {
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function add_new_row_is_not_shown_when_there_is_no_input()
     {
         Livewire::visit(AddNewItemComponent::class)
@@ -18,7 +18,7 @@ class AllowNewTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function add_new_row_appears_when_allow_new_is_true_and_text_is_entered()
     {
         Livewire::visit(AddNewItemComponent::class)
@@ -31,7 +31,7 @@ class AllowNewTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function add_new_row_is_visible_when_no_results_found()
     {
         Livewire::visit(AddNewItemComponent::class)
@@ -44,7 +44,7 @@ class AllowNewTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function first_result_should_be_highlighted_when_add_new_row_not_displayed_yet()
     {
         Livewire::visit(AddNewItemComponent::class)
@@ -55,7 +55,7 @@ class AllowNewTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function add_new_row_should_be_highlighed_by_default()
     {
         Livewire::visit(AddNewItemComponent::class)
@@ -67,7 +67,7 @@ class AllowNewTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function add_new_row_should_be_highlighed_after_arrowing_down_and_back_up()
     {
         Livewire::visit(AddNewItemComponent::class)
@@ -87,7 +87,7 @@ class AllowNewTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function first_result_should_be_selected_when_add_new_row_not_displayed_yet()
     {
         Livewire::visit(AddNewItemComponent::class)
@@ -100,7 +100,7 @@ class AllowNewTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function add_new_row_should_be_selected_but_nothing_happen()
     {
         Livewire::visit(AddNewItemComponent::class)
@@ -116,7 +116,7 @@ class AllowNewTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function highlighted_record_should_be_selected_even_when_add_new_row_displayed()
     {
         Livewire::visit(AddNewItemComponent::class)
@@ -131,7 +131,7 @@ class AllowNewTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function escape_does_not_clear_the_input_when_add_new_allowed()
     {
         Livewire::visit(AddNewItemComponent::class)
@@ -146,7 +146,7 @@ class AllowNewTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function clicking_away_does_not_clear_the_input_when_add_new_allowed()
     {
         Livewire::visit(AddNewItemComponent::class)

--- a/tests/Browser/AutocompleteBehaviourTest/AutocompleteBehaviourTest.php
+++ b/tests/Browser/AutocompleteBehaviourTest/AutocompleteBehaviourTest.php
@@ -7,7 +7,7 @@ use LivewireAutocomplete\Tests\Browser\TestCase;
 
 class AutocompleteBehaviourTest extends TestCase
 {
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function an_input_is_shown_on_screen()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -15,7 +15,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function dropdown_appears_when_input_is_focused()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -27,7 +27,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function dropdown_closes_when_anything_else_is_clicked_and_focus_is_removed()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -43,7 +43,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function dropdown_closes_when_escape_is_pressed_and_focus_removed()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -59,7 +59,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function dropdown_shows_list_of_results()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -73,7 +73,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function results_are_filtered_based_on_input()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -87,7 +87,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function down_arrow_focus_first_option_if_there_is_no_focus_in_dropdown()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -102,7 +102,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function down_arrow_focus_next_option_if_there_is_already_a_focus_in_dropdown()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -115,7 +115,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function down_arrow_focus_remains_on_last_result_in_dropdown()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -133,7 +133,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function up_arrow_clears_focus_if_first_option_is_focused_in_dropdown()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -149,7 +149,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function up_arrow_focuses_previous_option_if_there_is_another_option_before_current_in_dropdown()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -166,7 +166,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function up_arrow_focuses_nothing_if_nothing_currently_focused_in_dropdown()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -181,7 +181,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function home_key_focuses_first_result_in_dropdown()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -208,7 +208,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function end_key_focuses_last_result_in_dropdown()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -235,7 +235,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function focus_is_cleared_if_input_changes()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -251,7 +251,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function enter_key_selects_currently_focused_result()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -266,7 +266,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function enter_key_only_selects_if_there_is_a_currently_focused_result()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -280,7 +280,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function enter_key_submits_form_if_there_is_not_a_currently_focused_result()
     {
         Livewire::visit(PageWithAutocompleteInFormComponent::class)
@@ -293,7 +293,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function enter_key_does_not_submit_form_if_there_is_a_currently_focused_result()
     {
         Livewire::visit(PageWithAutocompleteInFormComponent::class)
@@ -307,7 +307,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function dropdown_is_hidden_and_focus_cleared_on_selection()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -326,7 +326,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function tab_key_selects_currently_focused_result()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -340,7 +340,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function tab_key_only_selects_if_there_is_a_currently_focused_result()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -354,7 +354,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function shift_tab_does_not_select_currently_focused_result()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -369,7 +369,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function mouse_hover_focuses_result()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -391,7 +391,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function mouse_leave_clears_focus_result()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -410,7 +410,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function mouse_click_selects_result()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -420,7 +420,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function selected_result_shown_in_input()
     {
         Livewire::visit(PageWithAutocompleteComponent::class)
@@ -430,7 +430,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function mouse_click_only_fires_once_on_newly_generated_morphed_results()
     {
         // This is a bug in livewire/livewire#763, this test triggers it without work around
@@ -448,7 +448,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function using_shift_does_not_clear_input()
     {
         // This bug has been fixed, but for some reason the test still fails, while a manual test confirms it is ok. Leaving here for future reference.
@@ -466,7 +466,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function input_does_not_get_overridden_when_multiple_network_requests_are_sent()
     {
         Livewire::visit(PageWithNetworkDelayComponent::class)
@@ -499,7 +499,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function pre_selected_value_is_shown_in_input()
     {
         Livewire::visit(PageWithPreSelectedValueComponent::class)
@@ -512,7 +512,7 @@ class AutocompleteBehaviourTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function pre_selected_value_can_be_changed_from_other_backend_actions()
     {
         Livewire::visit(PageWithPreSelectedValueComponent::class)

--- a/tests/Browser/AutocompleteDatabaseTest/AutocompleteDatabaseTest.php
+++ b/tests/Browser/AutocompleteDatabaseTest/AutocompleteDatabaseTest.php
@@ -16,7 +16,7 @@ class AutocompleteDatabaseTest extends TestCase
     protected function getEnvironmentSetUp($app)
     {
         parent::getEnvironmentSetUp($app);
-        
+
         $app['config']->set('database.default', 'testbench');
         $app['config']->set('database.connections.testbench', [
             'driver' => 'sqlite',
@@ -27,7 +27,7 @@ class AutocompleteDatabaseTest extends TestCase
         $app['config']->set('livewire.legacy_model_binding', true);
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function dropdown_shows_list_of_results()
     {
         Item::updateOrCreate(['id' => 1], ['name' => 'test1']);
@@ -50,7 +50,7 @@ class AutocompleteDatabaseTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function results_are_filtered_based_on_input()
     {
         Item::updateOrCreate(['id' => 1], ['name' => 'test1']);
@@ -72,7 +72,7 @@ class AutocompleteDatabaseTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function ensure_results_count_gets_updated_so_focus_cant_go_off_the_end_of_results()
     {
         Item::updateOrCreate(['id' => 1], ['name' => 'test1']);
@@ -97,7 +97,7 @@ class AutocompleteDatabaseTest extends TestCase
         ;
     }
 
-    // /** @test */
+    // #[\PHPUnit\Framework\Attributes\Test]
     // public function results_dropdown_is_not_shown_if_there_are_no_results_found()
     // {
     //     Item::updateOrCreate(['id' => 1], ['name' => 'test1']);
@@ -124,7 +124,7 @@ class AutocompleteDatabaseTest extends TestCase
     //     });
     // }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function selected_item_can_be_cleared()
     {
         Item::updateOrCreate(['id' => 1], ['name' => 'test1']);
@@ -144,7 +144,7 @@ class AutocompleteDatabaseTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function clear_button_cant_be_pressed_if_nothing_selected()
     {
         Item::updateOrCreate(['id' => 1], ['name' => 'test1']);
@@ -160,7 +160,7 @@ class AutocompleteDatabaseTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function input_cannot_be_focused_when_item_is_selected()
     {
         Item::updateOrCreate(['id' => 1], ['name' => 'test1']);

--- a/tests/Browser/AutocompleteEventsTest/AutocompleteEventsTest.php
+++ b/tests/Browser/AutocompleteEventsTest/AutocompleteEventsTest.php
@@ -7,7 +7,7 @@ use LivewireAutocomplete\Tests\Browser\TestCase;
 
 class AutocompleteEventsTest extends TestCase
 {
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function event_is_dispatched_on_input()
     {
         Livewire::visit(PageWithEventsComponent::class)
@@ -18,7 +18,7 @@ class AutocompleteEventsTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function event_is_dispatched_on_selected_item()
     {
         Livewire::visit(PageWithEventsComponent::class)
@@ -29,7 +29,7 @@ class AutocompleteEventsTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function event_is_dispatched_on_selected_item_and_input_is_changed()
     {
         Livewire::visit(PageWithEventsComponent::class)
@@ -44,7 +44,7 @@ class AutocompleteEventsTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function event_is_dispatched_when_selected_item_is_cleared()
     {
         Livewire::visit(PageWithEventsComponent::class)
@@ -58,7 +58,7 @@ class AutocompleteEventsTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function event_is_dispatched_when_input_is_reset()
     {
         Livewire::withQueryParams(['autoselect' => true])
@@ -73,7 +73,7 @@ class AutocompleteEventsTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function selected_is_cleared_when_clear_event_received()
     {
         Livewire::visit(PageWithEventsComponent::class)
@@ -91,7 +91,7 @@ class AutocompleteEventsTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function selected_is_set_when_set_event_received()
     {
         Livewire::visit(PageWithEventsComponent::class)

--- a/tests/Browser/AutocompleteLoadingTest/AutocompleteLoadingTest.php
+++ b/tests/Browser/AutocompleteLoadingTest/AutocompleteLoadingTest.php
@@ -7,7 +7,7 @@ use LivewireAutocomplete\Tests\Browser\TestCase;
 
 class AutocompleteLoadingTest extends TestCase
 {
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function loading_indicator_appears_when_request_is_taking_too_long()
     {
         Livewire::visit(AutocompleteWithLoadingComponent::class)

--- a/tests/Browser/AutocompleteOptionsTest/AutocompleteAutoselectTest.php
+++ b/tests/Browser/AutocompleteOptionsTest/AutocompleteAutoselectTest.php
@@ -7,7 +7,7 @@ use LivewireAutocomplete\Tests\Browser\TestCase;
 
 class AutocompleteAutoselectTest extends TestCase
 {
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function on_autoselect_first_option_is_selected_by_default()
     {
         Livewire::withQueryParams(['autoselect' => true])
@@ -19,7 +19,7 @@ class AutocompleteAutoselectTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function on_autoselect_up_arrow_stops_on_first_option()
     {
         Livewire::withQueryParams(['autoselect' => true])
@@ -35,7 +35,7 @@ class AutocompleteAutoselectTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function on_autoselect_down_arrow_stops_on_last_option()
     {
         Livewire::withQueryParams(['autoselect' => true])
@@ -52,7 +52,7 @@ class AutocompleteAutoselectTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function on_autoselect_mouse_out_does_not_deselect_current_option()
     {
         Livewire::withQueryParams(['autoselect' => true])
@@ -72,7 +72,7 @@ class AutocompleteAutoselectTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function on_autoselect_refocus_first_option_selected()
     {
         Livewire::withQueryParams(['autoselect' => true])
@@ -89,7 +89,7 @@ class AutocompleteAutoselectTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function on_autoselect_if_no_results_clear_input_on_selection()
     {
         Livewire::withQueryParams(['autoselect' => true])
@@ -104,7 +104,7 @@ class AutocompleteAutoselectTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function on_autoselect_clear_input_on_escape()
     {
         Livewire::withQueryParams(['autoselect' => true])
@@ -119,7 +119,7 @@ class AutocompleteAutoselectTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function on_autoselect_click_away_clears_input_text()
     {
         Livewire::withQueryParams(['autoselect' => true])
@@ -133,7 +133,7 @@ class AutocompleteAutoselectTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function on_autoselect_click_away_does_not_clear_selected_text()
     {
         Livewire::withQueryParams(['autoselect' => true])

--- a/tests/Browser/AutocompletePromptsTest/AutocompletePromptsTest.php
+++ b/tests/Browser/AutocompletePromptsTest/AutocompletePromptsTest.php
@@ -7,7 +7,7 @@ use LivewireAutocomplete\Tests\Browser\TestCase;
 
 class AutocompletePromptsTest extends TestCase
 {
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function placeholder_text_prompt_is_shown_on_focus()
     {
         Livewire::visit(AutocompletePromptsComponent::class)
@@ -19,7 +19,7 @@ class AutocompletePromptsTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function no_results_text_prompt_is_shown_if_nothing_found()
     {
         Livewire::visit(AutocompletePromptsComponent::class)

--- a/tests/Browser/DynamicComponentsTest/DynamicComponentsTest.php
+++ b/tests/Browser/DynamicComponentsTest/DynamicComponentsTest.php
@@ -7,7 +7,7 @@ use LivewireAutocomplete\Tests\Browser\TestCase;
 
 class DynamicComponentsTest extends TestCase
 {
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function it_shows_custom_component_when_passed_into_the_instance_through_props()
     {
         Livewire::visit(DynamicResultRowComponent::class)

--- a/tests/Browser/LoadOnFocusTest/LoadOnFocusTest.php
+++ b/tests/Browser/LoadOnFocusTest/LoadOnFocusTest.php
@@ -7,7 +7,7 @@ use LivewireAutocomplete\Tests\Browser\TestCase;
 
 class LoadOnFocusTest extends TestCase
 {
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function results_are_not_loaded_initially()
     {
         Livewire::visit(LoadOnFocusComponent::class)
@@ -18,7 +18,7 @@ class LoadOnFocusTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function it_loads_results_on_focus_if_action_is_present()
     {
         Livewire::visit(LoadOnFocusComponent::class)
@@ -30,7 +30,7 @@ class LoadOnFocusTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function it_only_loads_results_once_if_load_once_on_focus_is_set_to_true()
     {
         Livewire::visit(LoadOnFocusComponent::class)
@@ -44,7 +44,7 @@ class LoadOnFocusTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function it_loads_results_on_every_focus_if_load_once_on_focus_is_set_to_false()
     {
         Livewire::withQueryParams(['loadOnceOnFocus' => false])
@@ -57,7 +57,7 @@ class LoadOnFocusTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function it_can_call_focus_method_with_parameters()
     {
         Livewire::withQueryParams(['loadOnceOnFocus' => false, 'useParameters' => true])

--- a/tests/Browser/OptionsTest/OptionsTest.php
+++ b/tests/Browser/OptionsTest/OptionsTest.php
@@ -7,7 +7,7 @@ use LivewireAutocomplete\Tests\Browser\TestCase;
 
 class OptionsTest extends TestCase
 {
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function custom_attribute_names_can_be_passed_in_via_options()
     {
         Livewire::visit(CustomAttributesComponent::class)
@@ -18,7 +18,7 @@ class OptionsTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function default_inline_styles_are_used_when_inline_is_true()
     {
         Livewire::withQueryParams(['inline' => true])
@@ -28,7 +28,7 @@ class OptionsTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function default_overlay_styles_are_used_when_inline_is_false()
     {
         Livewire::withQueryParams(['inline' => false])
@@ -39,7 +39,7 @@ class OptionsTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function default_result_focus_styles_are_used()
     {
         Livewire::withQueryParams(['inline' => false])
@@ -50,7 +50,7 @@ class OptionsTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function custom_inline_styles_are_used_when_inline_is_true()
     {
         Livewire::withQueryParams(['inline' => true])
@@ -61,7 +61,7 @@ class OptionsTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function custom_overlay_styles_are_used_when_inline_is_false()
     {
         Livewire::withQueryParams(['inline' => false])
@@ -73,7 +73,7 @@ class OptionsTest extends TestCase
         ;
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function custom_result_focus_styles_are_used()
     {
         Livewire::withQueryParams(['inline' => false])

--- a/tests/Browser/ScrollIntoViewTest/ScrollIntoViewTest.php
+++ b/tests/Browser/ScrollIntoViewTest/ScrollIntoViewTest.php
@@ -7,7 +7,7 @@ use LivewireAutocomplete\Tests\Browser\TestCase;
 
 class ScrollIntoViewTest extends TestCase
 {
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function it_shows_custom_component_when_passed_into_the_instance_through_props()
     {
         Livewire::visit(ScrollIntoViewTestComponent::class)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,9 @@
 
 namespace LivewireAutocomplete\Tests;
 
+use Facebook\WebDriver\Remote\RemoteWebDriver;
 use LivewireDuskTestbench\TestCase as BaseTestCase;
+use Orchestra\Testbench\Dusk\Options as DuskOptions;
 
 class TestCase extends BaseTestCase
 {
@@ -13,5 +15,12 @@ class TestCase extends BaseTestCase
     public function viewsDirectory(): string
     {
         return __DIR__.'/Browser/views';
+    }
+
+    protected function driver(): RemoteWebDriver
+    {
+        DuskOptions::noSandbox();
+
+        return parent::driver();
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,11 +16,4 @@ class TestCase extends BaseTestCase
     {
         return __DIR__.'/Browser/views';
     }
-
-    protected function driver(): RemoteWebDriver
-    {
-        DuskOptions::noSandbox();
-
-        return parent::driver();
-    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,7 @@
 
 namespace LivewireAutocomplete\Tests;
 
-use Facebook\WebDriver\Remote\RemoteWebDriver;
 use LivewireDuskTestbench\TestCase as BaseTestCase;
-use Orchestra\Testbench\Dusk\Options as DuskOptions;
 
 class TestCase extends BaseTestCase
 {


### PR DESCRIPTION
This is supported from PHPUnit 10 so no issue with the current project state.

Thank you @adry84 for the details :wink:.